### PR TITLE
Fix win32 build via msvc project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 
+# macOS cruft
+.DS_Store
 portmidi_win/.DS_Store
 
-.DS_Store
+# Visual Studio cruft
+.vs/
+*.VC.db
+*.VC.VC.opendb
+Debug/
+Release/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ at the time of writing, the code has been compiled & tested on mac & windows.
 on mac, just run 'make'. you need to have portmidi and glfw3 installed.
 I used https://brew.sh/ to install these dependencies.
 
-on windows, the build is likely currently broken as I haven't had a chance to test it.
+on windows, only the 32-bit build is functional (linking to precompiled 32-bit portmidi static lib).
 I've included a portmidi static lib in the repo as I found it hard to compile from source.
 
 Dependencies

--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,11 @@
 #pragma comment(lib,"ws2_32.lib") // for sockets
 #pragma comment(lib,"opengl32.lib") // for wglGetProcAddress
 #pragma comment(lib,"portmidi_win/portmidi_s.lib") // for midi
-#pragma comment(lib,"imgui/glfw/lib-vc2010-32/glfw3.lib") // for imgui rendering
+#ifdef _WIN64
+#pragma comment(lib,"imgui/examples/libs/glfw/lib-vc2010-64/glfw3.lib") // for imgui rendering
+#else
+#pragma comment(lib,"imgui/examples/libs/glfw/lib-vc2010-32/glfw3.lib") // for imgui rendering
+#endif
 #pragma comment(lib,"legacy_stdio_definitions.lib") // for vsnprintf
 #define close closesocket
 #define chdir _chdir
@@ -308,12 +312,6 @@ int main(int argc, char**argv){
     glfwSetErrorCallback(glfw_error_callback);
     if (!glfwInit())
         return 1;
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-#if __APPLE__
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-#endif
     // Decide GL+GLSL versions
 #if __APPLE__
     // GL 3.2 + GLSL 150

--- a/midi2osc2.vcxproj
+++ b/midi2osc2.vcxproj
@@ -88,8 +88,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>imgui;imgui/gl3w;imgui\glfw\include;portmidi_win</AdditionalIncludeDirectories>
-      <ExceptionHandling>false</ExceptionHandling>
+      <AdditionalIncludeDirectories>imgui;imgui/examples/libs/gl3w;imgui/examples/libs/glfw/include;portmidi_win</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -104,7 +103,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>imgui;imgui/gl3w;imgui\glfw\include;portmidi_win</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>imgui;imgui/examples/libs/gl3w;imgui/examples/libs/glfw/include;portmidi_win</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -120,8 +119,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>imgui;imgui/gl3w;imgui\glfw\include;portmidi_win</AdditionalIncludeDirectories>
-      <ExceptionHandling>false</ExceptionHandling>
+      <AdditionalIncludeDirectories>imgui;imgui/examples/libs/gl3w;imgui/examples/libs/glfw/include;portmidi_win</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -139,7 +137,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>imgui;imgui/gl3w;imgui\glfw\include;portmidi_win</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>imgui;imgui/examples/libs/gl3w;imgui/examples/libs/glfw/include;portmidi_win</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -149,21 +147,25 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="imgui\gl3w\GL\gl3w.h" />
-    <ClInclude Include="imgui\gl3w\GL\glcorearb.h" />
+    <ClInclude Include="imgui\examples\imgui_impl_glfw.h" />
+    <ClInclude Include="imgui\examples\imgui_impl_opengl3.h" />
+    <ClInclude Include="imgui\examples\libs\gl3w\GL\gl3w.h" />
+    <ClInclude Include="imgui\examples\libs\gl3w\GL\glcorearb.h" />
     <ClInclude Include="imgui\imconfig.h" />
     <ClInclude Include="imgui\imgui.h" />
     <ClInclude Include="imgui\imgui_internal.h" />
-    <ClInclude Include="imgui\stb_rect_pack.h" />
-    <ClInclude Include="imgui\stb_textedit.h" />
-    <ClInclude Include="imgui\stb_truetype.h" />
+    <ClInclude Include="imgui\imstb_rectpack.h" />
+    <ClInclude Include="imgui\imstb_textedit.h" />
+    <ClInclude Include="imgui\imstb_truetype.h" />
     <ClInclude Include="imgui_impl_glfw_gl3.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="imgui\gl3w\GL\gl3w.c" />
+    <ClCompile Include="imgui\examples\imgui_impl_glfw.cpp" />
+    <ClCompile Include="imgui\examples\imgui_impl_opengl3.cpp" />
+    <ClCompile Include="imgui\examples\libs\gl3w\GL\gl3w.c" />
     <ClCompile Include="imgui\imgui.cpp" />
     <ClCompile Include="imgui\imgui_draw.cpp" />
-    <ClCompile Include="imgui_impl_glfw_gl3.cpp" />
+    <ClCompile Include="imgui\imgui_widgets.cpp" />
     <ClCompile Include="main.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/midi2osc2.vcxproj.filters
+++ b/midi2osc2.vcxproj.filters
@@ -27,26 +27,29 @@
     <ClInclude Include="imgui\imgui_internal.h">
       <Filter>Source Files</Filter>
     </ClInclude>
-    <ClInclude Include="imgui\stb_rect_pack.h">
+    <ClInclude Include="imgui\examples\libs\gl3w\GL\gl3w.h">
       <Filter>Source Files</Filter>
     </ClInclude>
-    <ClInclude Include="imgui\stb_textedit.h">
+    <ClInclude Include="imgui\examples\libs\gl3w\GL\glcorearb.h">
       <Filter>Source Files</Filter>
     </ClInclude>
-    <ClInclude Include="imgui\stb_truetype.h">
+    <ClInclude Include="imgui\examples\imgui_impl_opengl3.h">
       <Filter>Source Files</Filter>
     </ClInclude>
-    <ClInclude Include="imgui\gl3w\GL\gl3w.h">
+    <ClInclude Include="imgui\examples\imgui_impl_glfw.h">
       <Filter>Source Files</Filter>
     </ClInclude>
-    <ClInclude Include="imgui\gl3w\GL\glcorearb.h">
+    <ClInclude Include="imgui\imstb_rectpack.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="imgui\imstb_textedit.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="imgui\imstb_truetype.h">
       <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="imgui_impl_glfw_gl3.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -56,7 +59,16 @@
     <ClCompile Include="imgui\imgui_draw.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="imgui\gl3w\GL\gl3w.c">
+    <ClCompile Include="imgui\examples\libs\gl3w\GL\gl3w.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="imgui\examples\imgui_impl_opengl3.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="imgui\examples\imgui_impl_glfw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="imgui\imgui_widgets.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
minor fixes to get this building and running on Win32 with visual studio.
added files in vs project, added to ignore list, fixed duplicated glfw hints (had old code + new code) and this mess up under windows somehow, removed old code.

(there's a merge button down there!)